### PR TITLE
Volume sanity checks

### DIFF
--- a/00 Core/MWSE/mods/tew/AURA/sounds.lua
+++ b/00 Core/MWSE/mods/tew/AURA/sounds.lua
@@ -162,7 +162,7 @@ end
 function this.playImmediate(options)
 	local ref = options.reference or tes3.mobilePlayer.reference
 	local track = options.last and moduleData[options.module].new or getTrack(options)
-	local volume = options.volume or MAX
+	local volume = math.max(options.volume or MAX, 0)
 	local pitch = options.pitch or MAX
 
 	if track then
@@ -175,6 +175,7 @@ function this.playImmediate(options)
 				pitch = pitch,
 				loop = true,
 			}
+			moduleData[options.module].lastVolume = volume
 		end
 		moduleData[options.module].old = moduleData[options.module].new
 		moduleData[options.module].new = track


### PR DESCRIPTION
Attempting to fix corner case where a module is enabled but its volume slider is set to 0. This results in some impossible maths where 0 / 0 = `NaN` which would make a `timer` run infinite iterations when passed as `iterations` param.

Related, if config vol is 0 then `playWindoors()` math expression when calculating `windoorVol` would result in a negative value which would again break things. Instead of adding volume checks for each module, I've added `NaN` and negative number sanity checks in `sounds.lua` and `fader.lua`. Seems like the proper way to do it.

For reference, the `ITERS ~= ITERS` bit is kind of a hacky `NaN` check I came across, tested it and it looks like it works, so I threw it in.