### PR TITLE
Don't explicitly pass volume to sounds.remove()

### DIFF
--- a/00 Core/MWSE/mods/tew/AURA/Ambient/Interior/interiorMain.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Ambient/Interior/interiorMain.lua
@@ -139,6 +139,7 @@ local function cellCheck()
         onMusicSelection()
     end
 
+    intVol = config.intVol / 200
     local cell = tes3.getPlayerCell()
 
     -- Bugger off if we're not inside --

--- a/00 Core/MWSE/mods/tew/AURA/Ambient/Outdoor/outdoorMain.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Ambient/Outdoor/outdoorMain.lua
@@ -118,7 +118,7 @@ local function cellCheck(e)
 	if blockedWeathers[weatherNow] then
 		debugLog("Uneligible weather detected. Removing sounds.")
 		stopWindoors()
-		sounds.remove { module = moduleName, volume = OAvol }
+		sounds.remove { module = moduleName }
 		updateConditions()
 		return
 	end
@@ -180,7 +180,7 @@ local function cellCheck(e)
 	-- Exterior cells --
 	if (cell.isOrBehavesAsExterior and not isOpenPlaza(cell)) then
 		debugLog(string.format("Found exterior cell. useLast: %s", useLast))
-		if not useLast then sounds.remove { module = moduleName, volume = OAvol } end
+		if not useLast then sounds.remove { module = moduleName } end
 		sounds.play{
 			module = moduleName,
 			climate = climateNow,

--- a/00 Core/MWSE/mods/tew/AURA/Ambient/Populated/populatedMain.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Ambient/Populated/populatedMain.lua
@@ -60,19 +60,20 @@ local function cellCheck()
         return
     end
 
+    popVol = config.popVol / 200
     local cell = tes3.getPlayerCell()
 
     -- Wilderness shouldn't be considered populated --
     -- If cell name is nil (different from editorName!) then it's wilderness --
     if (not cell) or (not cell.name) then
         debugLog("Player in the wilderness. Returning.")
-        sounds.remove { module = moduleName, volume = popVol }
+        sounds.remove { module = moduleName }
         timeLast = nil
         typeCellLast = nil
         return
     elseif not (cell.isOrBehavesAsExterior and not isOpenPlaza(cell)) then -- Bugger off if we're inside --
         debugLog("Player in interior cell. Removing sounds immediately.")
-        sounds.removeImmediate { module = moduleName, volume = popVol }
+        sounds.removeImmediate { module = moduleName }
         timeLast = nil
         typeCellLast = nil
         return
@@ -89,7 +90,7 @@ local function cellCheck()
     -- No outside activity in ashstorms and that --
     if (weatherNow >= 4 and weatherNow <= 7) or (weatherNow == 8) and weatherNow ~= weatherLast then
         debugLog("Bad weather detected. Removing sounds.")
-        sounds.remove { module = moduleName, volume = popVol }
+        sounds.remove { module = moduleName }
         timeLast = nil
         typeCellLast = nil
         return
@@ -110,7 +111,7 @@ local function cellCheck()
 
     -- Otherwise reset and resolve --
     debugLog("Different conditions. Removing sounds.")
-    sounds.remove { module = moduleName, volume = popVol }
+    sounds.remove { module = moduleName }
     timeLast = nil
 
     -- Check if the cell is populated and whether it's night or day --

--- a/00 Core/MWSE/mods/tew/AURA/Misc/windSounds.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Misc/windSounds.lua
@@ -86,12 +86,13 @@ local function windCheck(e)
     end
 
     debugLog("Cell changed or time check triggered. Running cell check.")
+    windVol = config.windVol / 200
 
     -- Cell resolution --
     cell = tes3.getPlayerCell()
     if (not cell) then
 		debugLog("No cell detected. Returning.")
-        sounds.remove { module = moduleName, volume = windVol }
+        sounds.remove { module = moduleName }
 		return
 	end
 	debugLog("Cell: " .. cell.editorName)
@@ -112,7 +113,7 @@ local function windCheck(e)
     if blockedWeathers[weather.index] then
         debugLog("Uneligible weather detected. Removing sounds.")
         stopWindoors()
-        sounds.remove { module = moduleName, volume = windVol }
+        sounds.remove { module = moduleName }
         updateContitions()
         return
     end
@@ -125,7 +126,7 @@ local function windCheck(e)
     -- If it's super slow then bugger off, no sound for ya --
     if not windType then
         debugLog("Wind type is nil. Returning.")
-        sounds.remove { module = moduleName, volume = windVol }
+        sounds.remove { module = moduleName }
         updateContitions()
         return
     end
@@ -151,7 +152,7 @@ local function windCheck(e)
         if (cell.isOrBehavesAsExterior) then
             -- Using the same track when entering int/ext in same area; time/weather change will randomise it again --
             debugLog(string.format("Found exterior cell. useLast: %s", useLast))
-            if not useLast then sounds.remove { module = moduleName, volume = windVol } end
+            if not useLast then sounds.remove { module = moduleName } end
             sounds.play { module = moduleName, type = windType, volume = windVol, last = useLast }
         else
             debugLog("Found interior cell.")


### PR DESCRIPTION
Fader will by default use the last known module volume to remove tracks, which is the correct way to remove sounds when fading out. Explicitly passing volume can cause volume jumps when sounds aren't actually playing at the default module volume (e.g. when wheather changes in interiors)

Also included is [eb601cb](https://github.com/tewlwolow/AURA-old/commit/eb601cb9a9e0c28341a61e1a51455a25371ae493) from AURA-old which seems to have been lost during transition to the new repo.