### PR TITLE
Fix underwater detection

### DIFF
--- a/00 Core/MWSE/mods/tew/AURA/Interior Weather/interiorWeatherMain.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Interior Weather/interiorWeatherMain.lua
@@ -61,7 +61,7 @@ local function playThunder()
 end
 
 -- Not too proud of this --
-local function updateContitions(resetTimerFlag)
+local function updateConditions(resetTimerFlag)
 	if resetTimerFlag
 	and interiorTimer
 	and cell.isInterior
@@ -161,14 +161,14 @@ local function cellCheck(e)
 		sounds.remove { module = moduleName }
 		stopWindoors()
 		clearTimers()
-		updateContitions()
+		updateConditions()
 		return
 	end
 
 	-- Get out if the weather is the same as last time --
 	if weather == weatherLast and cellLast == cell then
 		debugLog("Same weather and cell detected.")
-		updateContitions(true)
+		updateConditions(true)
 		return
 	end
 
@@ -177,7 +177,7 @@ local function cellCheck(e)
 	if (isOpenPlaza(cell) == true)
 		and (weather == 6
 			or weather == 7) then
-		updateContitions()
+        updateConditions()
 		return
 	end
 
@@ -255,7 +255,7 @@ local function cellCheck(e)
 		thunderTimer = timer.start({ duration = thunderTime, iterations = 1, callback = playThunder, type = timer.real })
 	end
 
-	updateContitions()
+	updateConditions()
 	debugLog("Cell check complete.")
 end
 

--- a/00 Core/MWSE/mods/tew/AURA/Misc/underwater.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Misc/underwater.lua
@@ -21,10 +21,9 @@ local function underwaterReset(pitch)
     end
 end
 
-local underwaterSound = tes3.getSound("Underwater")
 local splashVol = config.volumes.misc.splashVol / 100
 local function underwaterCheck()
-    if tes3.mobilePlayer.underwater or (underwaterSound and underwaterSound:isLooping()) then
+    if tes3.mobilePlayer.underwater then
         if not cellData.playerUnderwater then
             cellData.playerUnderwater = true
             debugLog("Player underwater.")


### PR DESCRIPTION
Guess checking for looping underwater sound in addition to `tes3.mobilePlayer.underwater` was a dumb idea after all. Even though it was more precise and it worked with Water Breathing, it's prone to false positives when other mods use the underwater sound as a sound effect even when the player isn't underwater (e.g. attached via an activator in Balmora Waterworks).