### PR TITLE
Fix underwater volume scaling

### DIFF
--- a/00 Core/MWSE/mods/tew/AURA/Misc/underwaterRain.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Misc/underwaterRain.lua
@@ -1,28 +1,8 @@
 local common = require("tew.AURA.common")
 local debugLog = common.debugLog
+local soundData = require("tew.AURA.soundData")
 
-local weatherSounds = {
-	["Rain"] = 0,
-	["rain heavy"] = 0,
-	["Blight"] = 0,
-	["Ashstorm"] = 0,
-	["BM Blizzard"] = 0,
-	["tew_b_rainlight"] = 0,
-	["tew_b_rainmedium"] = 0,
-	["tew_b_rainheavy"] = 0,
-	["tew_s_rainlight"] = 0,
-	["tew_s_rainmedium"] = 0,
-	["tew_s_rainheavy"] = 0,
-	["tew_t_rainlight"] = 0,
-	["tew_t_rainmedium"] = 0,
-	["tew_t_rainheavy"] = 0,
-	["tew_rain_light"] = 0,
-	["tew_rain_medium"] = 0,
-	["tew_rain_heavy"] = 0,
-	["tew_thunder_light"] = 0,
-	["tew_thunder_medium"] = 0,
-	["tew_thunder_heavy"] = 0
-}
+local originalVolumes = {}
 
 local function setVolume(track, volume)
 	local rounded = math.round(volume, 2)
@@ -30,17 +10,24 @@ local function setVolume(track, volume)
 	track.volume = rounded
 end
 
+local function storeOriginalVolumes()
+    debugLog("Storing current weather volumes.")
+    table.clear(originalVolumes)
+    for _, sound in pairs(soundData.weatherLoops) do
+        originalVolumes[sound.id] = sound.volume
+	end
+end
+
 local function modifyVolume()
 	if not tes3.player or not tes3.mobilePlayer then return end
 	local waterLevel = tes3.player.cell.waterLevel or 0
 	local playerPosZ = tes3.player.position.z
-	for id, originalVol in pairs(weatherSounds) do
-		local sound = tes3.getSound(id)
-		if playerPosZ < waterLevel and sound:isPlaying() then
-			local volume = math.clamp(1 - math.remap(waterLevel - playerPosZ, 0, 1500, 0, originalVol), 0.0, originalVol)
+    local playerHeight = tes3.player.object.boundingBox and tes3.player.object.boundingBox.max.z or 0
+    for _, sound in pairs(soundData.weatherLoops) do
+        local originalVol = originalVolumes[sound.id]
+		if playerPosZ + playerHeight < waterLevel and sound:isPlaying() then
+			local volume = math.clamp(1 - math.remap(waterLevel - (playerPosZ + playerHeight), 0, 1500, 0, originalVol), 0.0, originalVol)
 			setVolume(sound, volume)
-		else
-			setVolume(sound, originalVol)
 		end
 	end
 end
@@ -52,32 +39,37 @@ local function underWaterCheck(e)
 	if mp then
 		if mp.isSwimming and not underwaterPrev then
 			underwaterPrev = true
+            debugLog("Player is swimming.")
 			event.trigger("AURA:enteredUnderwater")
 		elseif not mp.isSwimming and underwaterPrev then
 			underwaterPrev = false
+            debugLog("Player is not swimming.")
 			event.trigger("AURA:exitedUnderwater")
 		end
 	end
 end
 
-local function setOriginalVolume()
-	for id, _ in pairs(weatherSounds) do
-		local sound = tes3.getSound(id)
-		weatherSounds[id] = sound.volume
-	end
-end
-
 local function registerModify()
-	event.unregister(tes3.event.simulate, underWaterCheck)
+    storeOriginalVolumes() -- Store once more when going underwater, in case volumeSave has been used since `load`
 	event.unregister(tes3.event.simulate, modifyVolume)
 	event.register(tes3.event.simulate, modifyVolume)
+    debugLog("Started underwater volume scaling.")
 end
 
 local function unRegisterModify()
 	event.unregister(tes3.event.simulate, underWaterCheck)
-	event.register(tes3.event.simulate, underWaterCheck)
 	event.unregister(tes3.event.simulate, modifyVolume)
-	modifyVolume()
+    timer.start{
+        duration = 1,
+        callback = function()
+            debugLog("Stopped underwater volume scaling, restoring original volumes.")
+            for id, originalVol in pairs(originalVolumes) do
+                local sound = tes3.getSound(id)
+                setVolume(sound, originalVol)
+            end
+            event.register(tes3.event.simulate, underWaterCheck)
+        end,
+    }
 end
 
 event.unregister(tes3.event.simulate, underWaterCheck)
@@ -86,4 +78,7 @@ event.register(tes3.event.simulate, underWaterCheck)
 event.register("AURA:enteredUnderwater", registerModify)
 event.register("AURA:exitedUnderwater", unRegisterModify)
 
-event.register(tes3.event.load, setOriginalVolume)
+-- First we need to need to globally set all config volumes, then store them.
+-- i.e.: set vanilla rain tracks volume to 0 if using variable rain sounds
+-- The `load` event callback in volumeController should trigger first. And then this one.
+event.register(tes3.event.load, storeOriginalVolumes, { priority = -50 })

--- a/00 Core/MWSE/mods/tew/AURA/cellData.lua
+++ b/00 Core/MWSE/mods/tew/AURA/cellData.lua
@@ -16,7 +16,15 @@ local function update(e)
         this.windoors = common.getWindoors(this.cell)
     end
 end
-event.register("load", update)
+
+-- Prevent an unwanted splash_sml sound from playing when loading a game
+-- from underwater to a non-underwater location.
+local function resetPlayerUnderwater(e)
+    this.playerUnderwater = false
+    update(e)
+end
+
+event.register("load", resetPlayerUnderwater)
 event.register("loaded", update)
 event.register("cellChanged", update)
 event.register("weatherChangedImmediate", update)

--- a/00 Core/MWSE/mods/tew/AURA/i18n/en.lua
+++ b/00 Core/MWSE/mods/tew/AURA/i18n/en.lua
@@ -54,6 +54,7 @@ this.messages = {
     small = "small",
     exteriorVolume = "exterior volume",
     underwater = "underwater",
+    adjustingAuto = "Adjusting automatically",
 
 	refreshManifest = "Refresh manifest file",
 

--- a/00 Core/MWSE/mods/tew/AURA/i18n/fr.lua
+++ b/00 Core/MWSE/mods/tew/AURA/i18n/fr.lua
@@ -67,6 +67,7 @@ this.messages = {
     small = "petit",
     exteriorVolume = "le volume à l'extérieur",
     underwater = "sous l'eau",
+    adjustingAuto = "Ajustement automatique",
 
 	refreshManifest = "Actualiser le fichier manifeste",
 

--- a/00 Core/MWSE/mods/tew/AURA/soundBuilder.lua
+++ b/00 Core/MWSE/mods/tew/AURA/soundBuilder.lua
@@ -145,45 +145,45 @@ local function buildWeatherSounds()
 
 	filename = soundDir .. wDir .. "\\big\\rl.wav"
 	objectId = "tew_b_rainlight"
-	soundData.interiorRainLoops["big"]["light"] = createSound(objectId, filename)
+	soundData.interiorRainLoops["big"]["light"] = createSound(objectId, filename, soundData.weatherLoops)
 
 	filename = soundDir .. wDir .. "\\big\\rm.wav"
 	objectId = "tew_b_rainmedium"
-    soundData.interiorRainLoops["big"]["medium"] = createSound(objectId, filename)
+    soundData.interiorRainLoops["big"]["medium"] = createSound(objectId, filename, soundData.weatherLoops)
 	createSound(objectId, filename, soundData.interiorWeather["big"], 4)
 	createSound(objectId, filename, soundData.interiorWeather["big"], 5)
 
 	filename = soundDir .. wDir .. "\\big\\rh.wav"
 	objectId = "tew_b_rainheavy"
-	soundData.interiorRainLoops["big"]["heavy"] = createSound(objectId, filename)
+	soundData.interiorRainLoops["big"]["heavy"] = createSound(objectId, filename, soundData.weatherLoops)
 
 	filename = soundDir .. wDir .. "\\sma\\rl.wav"
 	objectId = "tew_s_rainlight"
-	soundData.interiorRainLoops["sma"]["light"] = createSound(objectId, filename)
+	soundData.interiorRainLoops["sma"]["light"] = createSound(objectId, filename, soundData.weatherLoops)
 
 	filename = soundDir .. wDir .. "\\sma\\rm.wav"
 	objectId = "tew_s_rainmedium"
-    soundData.interiorRainLoops["sma"]["medium"] = createSound(objectId, filename)
+    soundData.interiorRainLoops["sma"]["medium"] = createSound(objectId, filename, soundData.weatherLoops)
 	createSound(objectId, filename, soundData.interiorWeather["sma"], 4)
 	createSound(objectId, filename, soundData.interiorWeather["sma"], 5)
 
 	filename = soundDir .. wDir .. "\\sma\\rh.wav"
 	objectId = "tew_s_rainheavy"
-	soundData.interiorRainLoops["sma"]["heavy"] = createSound(objectId, filename)
+	soundData.interiorRainLoops["sma"]["heavy"] = createSound(objectId, filename, soundData.weatherLoops)
 
 	filename = soundDir .. wDir .. "\\ten\\rl.wav"
 	objectId = "tew_t_rainlight"
-	soundData.interiorRainLoops["ten"]["light"] = createSound(objectId, filename)
+	soundData.interiorRainLoops["ten"]["light"] = createSound(objectId, filename, soundData.weatherLoops)
 
 	filename = soundDir .. wDir .. "\\ten\\rm.wav"
 	objectId = "tew_t_rainmedium"
-    soundData.interiorRainLoops["ten"]["medium"] = createSound(objectId, filename)
+    soundData.interiorRainLoops["ten"]["medium"] = createSound(objectId, filename, soundData.weatherLoops)
 	createSound(objectId, filename, soundData.interiorWeather["ten"], 4)
 	createSound(objectId, filename, soundData.interiorWeather["ten"], 5)
 
 	filename = soundDir .. wDir .. "\\ten\\rh.wav"
 	objectId = "tew_t_rainheavy"
-	soundData.interiorRainLoops["ten"]["heavy"] = createSound(objectId, filename)
+	soundData.interiorRainLoops["ten"]["heavy"] = createSound(objectId, filename, soundData.weatherLoops)
 
 	filename, objectId = nil, nil
 end
@@ -274,27 +274,27 @@ local function buildRain()
 
 	filename = "tew\\A\\R\\tew_rain_light.wav"
 	objectId = "tew_rain_light"
-    soundData.rainLoops["Rain"]["light"] = createSound(objectId, filename)
+    soundData.rainLoops["Rain"]["light"] = createSound(objectId, filename, soundData.weatherLoops)
 
 	filename = "tew\\A\\R\\tew_rain_medium.wav"
 	objectId = "tew_rain_medium"
-	soundData.rainLoops["Rain"]["medium"] = createSound(objectId, filename)
+	soundData.rainLoops["Rain"]["medium"] = createSound(objectId, filename, soundData.weatherLoops)
 
 	filename = "tew\\A\\R\\tew_rain_heavy.wav"
 	objectId = "tew_rain_heavy"
-	soundData.rainLoops["Rain"]["heavy"] = createSound(objectId, filename)
+	soundData.rainLoops["Rain"]["heavy"] = createSound(objectId, filename, soundData.weatherLoops)
 
 	filename = "tew\\A\\R\\tew_thunder_light.wav"
 	objectId = "tew_thunder_light"
-	soundData.rainLoops["Thunderstorm"]["light"] = createSound(objectId, filename)
+	soundData.rainLoops["Thunderstorm"]["light"] = createSound(objectId, filename, soundData.weatherLoops)
 
 	filename = "tew\\A\\R\\tew_thunder_medium.wav"
 	objectId = "tew_thunder_medium"
-	soundData.rainLoops["Thunderstorm"]["medium"] = createSound(objectId, filename)
+	soundData.rainLoops["Thunderstorm"]["medium"] = createSound(objectId, filename, soundData.weatherLoops)
 
 	filename = "tew\\A\\R\\tew_thunder_heavy.wav"
 	objectId = "tew_thunder_heavy"
-	soundData.rainLoops["Thunderstorm"]["heavy"] = createSound(objectId, filename)
+	soundData.rainLoops["Thunderstorm"]["heavy"] = createSound(objectId, filename, soundData.weatherLoops)
 
 	filename, objectId = nil, nil
 end
@@ -319,12 +319,20 @@ local function getWeatherSounds()
 	local ashSound = tes3.getSound("ashstorm")
 	local blightSound = tes3.getSound("Blight")
 	local blizzardSound = tes3.getSound("BM Blizzard")
+	local rainSound = tes3.getSound("Rain")
+	local thunderSound = tes3.getSound("rain heavy")
 
 	for type in pairs(soundData.interiorWeather) do
 		table.insert(soundData.interiorWeather[type], 6, ashSound)
 		table.insert(soundData.interiorWeather[type], 7, blightSound)
 		table.insert(soundData.interiorWeather[type], 9, blizzardSound)
 	end
+
+    table.insert(soundData.weatherLoops, ashSound)
+    table.insert(soundData.weatherLoops, blightSound)
+    table.insert(soundData.weatherLoops, blizzardSound)
+    table.insert(soundData.weatherLoops, rainSound)
+    table.insert(soundData.weatherLoops, thunderSound)
 end
 
 local function checkForRemovedFiles()

--- a/00 Core/MWSE/mods/tew/AURA/soundData.lua
+++ b/00 Core/MWSE/mods/tew/AURA/soundData.lua
@@ -93,4 +93,6 @@ this.interiorRainLoops = {
     }
 }
 
+this.weatherLoops = {} -- Stores vanilla rain, extreme weather and AURA variable rain sound objects
+
 return this

--- a/00 Core/MWSE/mods/tew/AURA/volumeController.lua
+++ b/00 Core/MWSE/mods/tew/AURA/volumeController.lua
@@ -103,4 +103,51 @@ function this.adjustVolume(options)
     end
 end
 
+function this.setConfigVolumes()
+    local config = mwse.loadConfig("AURA", defaults)
+    local vanillaRain = tes3.getSound("Rain")
+    local vanillaStorm = tes3.getSound("rain heavy")
+    local ashstorm = tes3.getSound("ashstorm")
+    local blight = tes3.getSound("Blight")
+    local blizzard = tes3.getSound("BM Blizzard")
+    debugLog("Setting config volumes.")
+    if config.rainSounds then
+        debugLog("Using variable rain sounds.")
+        if vanillaRain then this.setVolume(vanillaRain, 0) end
+        if vanillaStorm then this.setVolume(vanillaStorm, 0) end
+    end
+    for weatherName, data in pairs(soundData.rainLoops) do
+        for rainType, track in pairs(data) do
+            if track then
+                this.setVolume(track, config.volumes.rain[weatherName][rainType] / 100)
+            end
+        end
+    end
+    if ashstorm then this.setVolume(ashstorm, config.volumes.extremeWeather["Ashstorm"] / 100) end
+    if blight then this.setVolume(blight, config.volumes.extremeWeather["Blight"] / 100) end
+    if blizzard then this.setVolume(blizzard, config.volumes.extremeWeather["Blizzard"] / 100) end
+end
+
+function this.printConfigVolumes()
+    local config = mwse.loadConfig("AURA", defaults)
+    debugLog("Printing config volumes.")
+    for configKey, volumeTable in pairs(config.volumes) do
+        if configKey == "modules" then
+            for moduleName, moduleVol in pairs(volumeTable) do
+                debugLog(string.format("[%s] vol: %s, big: %s, sma: %s, und: %s", moduleName, moduleVol.volume, moduleVol.big, moduleVol.sma, moduleVol.und))
+            end
+        elseif configKey == "rain" then
+            for weatherName, weatherData in pairs(volumeTable) do
+                debugLog(string.format("[%s] light: %s, medium: %s, heavy: %s", weatherName, weatherData.light, weatherData.medium, weatherData.heavy))
+            end
+        else
+            for volumeTableKey, volumeTableValue in pairs(volumeTable) do
+                debugLog(string.format("[%s] %s: %s", configKey, volumeTableKey, volumeTableValue))
+            end
+        end
+    end
+end
+
+event.register(tes3.event.load, this.setConfigVolumes)
+
 return this


### PR DESCRIPTION
Previously, `underwaterCheck()` would stop running once the player went underwater. `registerModify()` would unregister it and never re-register it. So, once underwater, `modifyVolume()` would run in an infinite loop in simulate, even when on land, continuously setting original volumes, and causing some weird sound glitches when the weather was changing.

This PR fixes this issue and also introduces `playerHeight` when calculating the new modified volume, for more accurate scaling. Now volume scaling will begin only when the player's head (`playerPosZ` + `playerHeight`) is below water level.

Also disabling sliders for rain/extreme weather in our volume adjuster menu while underwater volume scaling is in effect, and informing the player of current scaled volume when the menu is being toggled on.

Aaaaaand some minor fixes/refactors. Tested, all ok, but lemme know if completely off rails here lel