### PR TITLE
Windoors/useLast logic fix

### DIFF
--- a/00 Core/MWSE/mods/tew/AURA/Ambient/Outdoor/outdoorMain.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Ambient/Outdoor/outdoorMain.lua
@@ -72,6 +72,7 @@ local function playWindoors()
 				module = moduleName,
 				newTrack = track,
 				newRef = windoor,
+				noQueue = true,
 			}
 		end
 	end
@@ -166,7 +167,6 @@ local function cellCheck(e)
 	-- Exterior cells --
 	if (cell.isOrBehavesAsExterior and not isOpenPlaza(cell)) then
 		debugLog(string.format("Found exterior cell. useLast: %s", useLast))
-		if not useLast then sounds.remove { module = moduleName } end
 		sounds.play {
 			module = moduleName,
 			climate = climateNow,

--- a/00 Core/MWSE/mods/tew/AURA/Ambient/Outdoor/outdoorMain.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Ambient/Outdoor/outdoorMain.lua
@@ -12,7 +12,6 @@ local isOpenPlaza = common.isOpenPlaza
 
 local moduleInteriorWeather = config.moduleInteriorWeather
 local playInteriorAmbient = config.playInteriorAmbient
-local windoorVol, windoorPitch = 0, 0
 
 local moduleName = "outdoor"
 
@@ -59,28 +58,21 @@ local function stopWindoors(immediateFlag)
 end
 
 -- Because MW engine will otherwise scrap the sound and not put it up again. Dumb thing --
-local function playWindoors(useLast)
+local function playWindoors()
 	if table.empty(cellData.windoors) then return end
 	debugLog("Updating interior doors and windows.")
 	local playerPos = tes3.player.position:copy()
-	local playLast
-	for i, windoor in ipairs(cellData.windoors) do
-		-- Get the first closest windoor and set the proper flag, the rest will follow
-		if i == 1 then
-			playLast = useLast
-		else
-			playLast = true
-		end
-
-		if windoor ~= nil and playerPos:distance(windoor.position:copy()) < 1800 then
+	
+	for _, windoor in ipairs(cellData.windoors) do
+		
+		local track = windoor.tempData.tew.AURA.OUT.track
+		
+		if windoor ~= nil and playerPos:distance(windoor.position:copy()) < 1800
+		and not common.getTrackPlaying(track, windoor) then
 			sounds.play {
 				module = moduleName,
-				climate = climateNow,
-				time = timeNow,
-				volume = windoorVol,
-				pitch = windoorPitch,
+				newTrack = track,
 				newRef = windoor,
-				last = playLast,
 			}
 		end
 	end
@@ -213,9 +205,18 @@ local function cellCheck(e)
 			if not table.empty(cellData.windoors) then
 				debugLog("Found " ..
 				#cellData.windoors .. " windoor(s). Playing interior loops. useLast: " .. tostring(useLast))
-				windoorVol = volumeController.getVolume { module = moduleName }
-				windoorPitch = volumeController.getPitch(moduleName)
-				playWindoors(useLast)
+				local windoorTrack = useLast and moduleData[moduleName].new or sounds.getTrack{
+					module = moduleName,
+					climate = climateNow,
+					time = timeNow,
+				}
+				for _, windoor in ipairs(cellData.windoors) do
+					local tempData = windoor.tempData
+					if not tempData.tew then tempData.tew = {} end
+					if not tempData.tew.AURA then tempData.tew.AURA = {} end
+					if not tempData.tew.AURA.OUT then tempData.tew.AURA.OUT = {} end
+					tempData.tew.AURA.OUT.track = windoorTrack
+				end
 				updateConditions(true)
 				return
 				-- Special case - where the lack of windoors in otherwise eligible 'big' interior would break our state and make it stale

--- a/00 Core/MWSE/mods/tew/AURA/Ambient/Outdoor/outdoorMain.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Ambient/Outdoor/outdoorMain.lua
@@ -6,7 +6,6 @@ local defaults = require("tew.AURA.defaults")
 local modules = require("tew.AURA.modules")
 local moduleData = modules.data
 local sounds = require("tew.AURA.sounds")
-local volumeController = require("tew.AURA.volumeController")
 
 local isOpenPlaza = common.isOpenPlaza
 
@@ -260,8 +259,6 @@ local function resetWindoors(e)
 	if interiorTimer then interiorTimer:pause() end
 	debugLog("Resetting windoors.")
 	stopWindoors(true)
-	windoorVol = volumeController.getVolume { module = moduleName }
-	windoorPitch = volumeController.getPitch(moduleName)
 	if interiorTimer then interiorTimer:reset() end
 end
 

--- a/00 Core/MWSE/mods/tew/AURA/Interior Weather/interiorWeatherMain.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Interior Weather/interiorWeatherMain.lua
@@ -6,12 +6,10 @@ local modules = require("tew.AURA.modules")
 local moduleData = modules.data
 local sounds = require("tew.AURA.sounds")
 local soundData = require("tew.AURA.soundData")
-local volumeController = require("tew.AURA.volumeController")
 
 local moduleName = "interiorWeather"
 
 local transitionScalarThreshold = 0.65
-local windoorVol, windoorPitch = 0, 0
 local sound
 
 local interiorTimer, scalarTimer, transitionScalarLast
@@ -92,14 +90,13 @@ local function playWindoors()
 	if table.empty(cellData.windoors) then return end
 	debugLog("Updating interior doors and windows.")
 	local playerPos = tes3.player.position:copy()
-	for i, windoor in ipairs(cellData.windoors) do
-		if windoor ~= nil and playerPos:distance(windoor.position:copy()) < 1800 then
+	for _, windoor in ipairs(cellData.windoors) do
+		if windoor ~= nil and playerPos:distance(windoor.position:copy()) < 1800
+		and not common.getTrackPlaying(sound, windoor) then
 			sounds.play {
 				module = moduleName,
 				newTrack = sound,
 				newRef = windoor,
-				volume = windoorVol,
-				pitch = windoorPitch,
 			}
 		end
 	end
@@ -237,9 +234,6 @@ local function cellCheck(e)
 	else
 		if not table.empty(cellData.windoors) then
 			debugLog("Found " .. #cellData.windoors .. " windoor(s). Playing interior loops.")
-			windoorVol = volumeController.getVolume { module = moduleName }
-			windoorPitch = volumeController.getPitch(moduleName)
-			playWindoors()
 			interiorTimer:reset()
 			thunRef = cellData.windoors[math.random(1, #cellData.windoors)]
 		end
@@ -330,8 +324,6 @@ local function resetWindoors(e)
 	if interiorTimer then interiorTimer:pause() end
 	debugLog("Resetting windoors.")
 	stopWindoors(true)
-	windoorVol = volumeController.getVolume { module = moduleName }
-	windoorPitch = volumeController.getPitch(moduleName)
 	if interiorTimer then interiorTimer:reset() end
 end
 
@@ -340,7 +332,6 @@ local function runResetter()
 	cell, cellLast, thunRef, thunder, interiorTimer, scalarTimer, thunderTimer, thunderTime, interiorType, weather, weatherLast, sound =
 	nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil
 	transitionScalarLast = nil
-	windoorVol, windoorPitch = 0, 0
 end
 
 event.register("cellChanged", onCellChanged, { priority = -165 })

--- a/00 Core/MWSE/mods/tew/AURA/Interior Weather/interiorWeatherMain.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Interior Weather/interiorWeatherMain.lua
@@ -97,6 +97,7 @@ local function playWindoors()
 				module = moduleName,
 				newTrack = sound,
 				newRef = windoor,
+				noQueue = true,
 			}
 		end
 	end

--- a/00 Core/MWSE/mods/tew/AURA/Misc/windSounds.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Misc/windSounds.lua
@@ -5,7 +5,6 @@ local defaults = require("tew.AURA.defaults")
 local modules = require("tew.AURA.modules")
 local moduleData = modules.data
 local sounds = require("tew.AURA.sounds")
-local volumeController = require("tew.AURA.volumeController")
 local moduleName = "wind"
 local playInteriorWind = config.playInteriorWind
 local windType, cell
@@ -245,8 +244,6 @@ local function resetWindoors(e)
     if interiorTimer then interiorTimer:pause() end
     debugLog("Resetting windoors.")
     stopWindoors(true)
-    windoorVol = volumeController.getVolume{module = moduleName}
-    windoorPitch = volumeController.getPitch(moduleName)
     if interiorTimer then interiorTimer:reset() end
 end
 

--- a/00 Core/MWSE/mods/tew/AURA/Misc/windSounds.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Misc/windSounds.lua
@@ -8,7 +8,6 @@ local sounds = require("tew.AURA.sounds")
 local volumeController = require("tew.AURA.volumeController")
 local moduleName = "wind"
 local playInteriorWind = config.playInteriorWind
-local windoorVol, windoorPitch = 0, 0
 local windType, cell
 local windTypeLast, cellLast
 local interiorTimer
@@ -54,32 +53,24 @@ local function stopWindoors(immediateFlag)
 	end
 end
 
--- TODO: don't getVol every time
-local function playWindoors(useLast)
-	if table.empty(cellData.windoors) then return end
-	debugLog("Updating interior doors and windows.")
-	local playerPos = tes3.player.position:copy()
-	local playLast
-	for i, windoor in ipairs(cellData.windoors) do
-
-        -- Get the first closest windoor and set the proper flag, the rest will follow
-        if i == 1 then
-			playLast = useLast
-		else
-			playLast = true
-		end
-
-		if windoor ~= nil and playerPos:distance(windoor.position:copy()) < 1800 then
-            sounds.play{
+local function playWindoors()
+    if table.empty(cellData.windoors) then return end
+    debugLog("Updating interior doors and windows.")
+    local playerPos = tes3.player.position:copy()
+    
+    for _, windoor in ipairs(cellData.windoors) do
+        
+        local track = windoor.tempData.tew.AURA.WIND.track
+        
+        if windoor ~= nil and playerPos:distance(windoor.position:copy()) < 1800
+        and not common.getTrackPlaying(track, windoor) then
+            sounds.play {
                 module = moduleName,
-                type = windType,
-                volume = windoorVol,
-                pitch = windoorPitch,
+                newTrack = track,
                 newRef = windoor,
-                last = playLast,
             }
-		end
-	end
+        end
+    end
 end
 
 -- Resolve data and play or remove wind sounds --
@@ -182,10 +173,19 @@ local function windCheck(e)
             else
                 debugLog("Found big interior cell.")
                 if not table.empty(cellData.windoors) then
-                    debugLog("Found " .. #cellData.windoors .. " windoor(s). Playing interior loops.")
-                    windoorVol = volumeController.getVolume{module = moduleName}
-                    windoorPitch = volumeController.getPitch(moduleName)
-                    playWindoors(useLast)
+                    debugLog("Found " ..
+                    #cellData.windoors .. " windoor(s). Playing interior loops. useLast: " .. tostring(useLast))
+                    local windoorTrack = useLast and moduleData[moduleName].new or sounds.getTrack{
+                        module = moduleName,
+                        type = windType,
+                    }
+                    for _, windoor in ipairs(cellData.windoors) do
+                        local tempData = windoor.tempData
+                        if not tempData.tew then tempData.tew = {} end
+                        if not tempData.tew.AURA then tempData.tew.AURA = {} end
+                        if not tempData.tew.AURA.WIND then tempData.tew.AURA.WIND = {} end
+                        tempData.tew.AURA.WIND.track = windoorTrack
+                    end
                     updateConditions(true)
                     return
                 end

--- a/00 Core/MWSE/mods/tew/AURA/Misc/windSounds.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Misc/windSounds.lua
@@ -67,6 +67,7 @@ local function playWindoors()
                 module = moduleName,
                 newTrack = track,
                 newRef = windoor,
+                noQueue = true,
             }
         end
     end
@@ -147,7 +148,6 @@ local function windCheck(e)
         if (cell.isOrBehavesAsExterior) then
             -- Using the same track when entering int/ext in same area; time/weather change will randomise it again --
             debugLog(string.format("Found exterior cell. useLast: %s", useLast))
-            if not useLast then sounds.remove { module = moduleName } end
             sounds.play { module = moduleName, type = windType, last = useLast }
         else
             debugLog("Found interior cell.")

--- a/00 Core/MWSE/mods/tew/AURA/common.lua
+++ b/00 Core/MWSE/mods/tew/AURA/common.lua
@@ -127,7 +127,9 @@ function this.getWindoors(cell)
 	local windoors = {}
 	for door in cell:iterateReferences(tes3.objectType.door) do
 		if door.destination then
-			if (door.destination.cell.isOrBehavesAsExterior) and not (this.isOpenPlaza(cell)) then
+			if (door.destination.cell.isOrBehavesAsExterior)
+			and not (this.isOpenPlaza(cell))
+			and door.tempData then
 				table.insert(windoors, door)
 			end
 		end
@@ -139,7 +141,7 @@ function this.getWindoors(cell)
 		for stat in cell:iterateReferences(tes3.objectType.static) do
 			if (not string.find(cell.name:lower(), "plaza")) then
 				for _, window in pairs(this.windows) do
-					if string.find(stat.object.id:lower(), window) then
+					if string.find(stat.object.id:lower(), window) and stat.tempData then
 						table.insert(windoors, stat)
 					end
 				end

--- a/00 Core/MWSE/mods/tew/AURA/fader.lua
+++ b/00 Core/MWSE/mods/tew/AURA/fader.lua
@@ -161,6 +161,7 @@ function this.fade(options)
             common.setRemove(this.inProgress[fadeType], fadeInProgress)
             if mData then
                 mData.old = track
+                mData.oldRef = ref
                 mData.lastVolume = currentVolume
                 debugLog(string.format("[%s] lastVolume is now: %s", moduleName, currentVolume))
             end


### PR DESCRIPTION
Windoors update mechanism appears to be broken.

`useLast` is sometimes a table when it should be `true`/`false`. That's because the function param is missing when the timer runs its callback. And we're always trying to get a new track for the first windoor. We should probably ditch the `useLast` param to `playWindoors()` and use an alternative

I'm thinking windoor `tempData` and resolve the track early, on module cell check