### PR TITLE
Generalize text input focus detection

### DIFF
--- a/00 Core/MWSE/mods/tew/AURA/volumeSave.lua
+++ b/00 Core/MWSE/mods/tew/AURA/volumeSave.lua
@@ -40,11 +40,8 @@ end
 local function textInputIsActive()
     local inputFocus = getTextInputFocus()
 
-    -- Patch for UI Expansion not releasing text input after leaving menu mode
-    if not tes3ui.menuMode()
-        and inputFocus
-        and inputFocus.widget
-        and inputFocus.widget.element.name == "UIEXP:FiltersearchBlock" then
+    -- Patch for mods that don't release text input after leaving menu mode (UIExp, etc)
+    if not tes3ui.menuMode() and inputFocus then
         tes3ui.acquireTextInput(nil)
         inputFocus = getTextInputFocus()
     end

--- a/00 Core/MWSE/mods/tew/AURA/volumeSave.lua
+++ b/00 Core/MWSE/mods/tew/AURA/volumeSave.lua
@@ -354,11 +354,11 @@ end
 
 local function createWindow()
     local menu = tes3ui.createMenu { id = this.id_menu, dragFrame = true }
-    tes3ui.enterMenuMode(this.id_menu)
 
     menu.text = "AURA"
     menu.width = 430
     menu.height = 600
+
     if this.positionX and this.positionY then
         menu.positionX = this.positionX
         menu.positionY = this.positionY
@@ -375,10 +375,7 @@ local function createWindow()
 
     updateHeader()
 
-    menu.width = 430
-    menu.height = 600
     menu:updateLayout()
-    menu.visible = true
 end
 
 local function redraw()
@@ -414,20 +411,20 @@ function this.toggle(e)
             createWindow()
             if (not tes3ui.menuMode()) then
                 tes3ui.enterMenuMode(this.id_menu)
-                debugLog("Toggle on.")
             end
+            debugLog("Toggle on.")
         else
             this.positionX = menu.positionX
             this.positionY = menu.positionY
             menu:destroy()
             if (tes3ui.menuMode()) then
                 tes3ui.leaveMenuMode()
-                debugLog("Toggle off.")
             end
             if this.config then mwse.saveConfig("AURA", this.config) end
             this.configPrevious = nil
             this.entries = 0
             table.clear(this.adjustedModules)
+            debugLog("Toggle off.")
         end
     end
 end


### PR DESCRIPTION
You were most definitely right about keeping it generalized https://github.com/tewlwolow/AURA/pull/10#discussion_r1390313692

This should cover any mod that doesn't release text input after leaving menu mode, not just UIExp.