### PR TITLE
Fix crossfade, revise queue logic

### DIFF
--- a/00 Core/MWSE/mods/tew/AURA/Ambient/Outdoor/outdoorMain.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Ambient/Outdoor/outdoorMain.lua
@@ -69,9 +69,10 @@ local function playWindoors()
 			and not common.getTrackPlaying(track, windoor) then
 			sounds.play {
 				module = moduleName,
-				newTrack = track,
-				newRef = windoor,
+				track = track,
+				reference = windoor,
 				noQueue = true,
+				noCrossfade = true,
 			}
 		end
 	end

--- a/00 Core/MWSE/mods/tew/AURA/Interior Weather/interiorWeatherMain.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Interior Weather/interiorWeatherMain.lua
@@ -95,9 +95,10 @@ local function playWindoors()
 			and not common.getTrackPlaying(sound, windoor) then
 			sounds.play {
 				module = moduleName,
-				newTrack = sound,
-				newRef = windoor,
+				track = sound,
+				reference = windoor,
 				noQueue = true,
+				noCrossfade = true,
 			}
 		end
 	end

--- a/00 Core/MWSE/mods/tew/AURA/Misc/windSounds.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Misc/windSounds.lua
@@ -65,9 +65,10 @@ local function playWindoors()
         and not common.getTrackPlaying(track, windoor) then
             sounds.play {
                 module = moduleName,
-                newTrack = track,
-                newRef = windoor,
+                track = track,
+                reference = windoor,
                 noQueue = true,
+                noCrossfade = true,
             }
         end
     end

--- a/00 Core/MWSE/mods/tew/AURA/Sounds On Statics/staticsMain.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Sounds On Statics/staticsMain.lua
@@ -32,7 +32,7 @@ local function playing(sound, ref)
     return common.getTrackPlaying(sound, ref)
 end
 local function play(moduleName, sound, ref)
-    sounds.play { module = moduleName, newTrack = sound, newRef = ref }
+    sounds.play { module = moduleName, track = sound, reference = ref }
 end
 local function playImmediate(moduleName, sound, ref)
     sounds.playImmediate { module = moduleName, track = sound, reference = ref }
@@ -109,19 +109,18 @@ local function adjustWeatherVolume()
         return
     end
 
-    local mData = moduleData[moduleName]
     local sheltered = cellData.currentShelter.ref
 
     if (not cellData.isWeatherVolumeDynamic) and (sheltered) then
         local trackVolume = math.round(weatherTrack.volume, 2)
         weatherVolumeDelta = getVolume { module = moduleName, trackVolume = trackVolume }
         if (weatherVolumeDelta == 0) then return end
-        mData.lastVolume = trackVolume
+        moduleData[moduleName].lastVolume = trackVolume
         fadeWeatherTrack("out", weatherTrack)
         cellData.isWeatherVolumeDynamic = true
     elseif (cellData.isWeatherVolumeDynamic) and (not sheltered) and (weatherVolumeDelta > 0) then
         fadeWeatherTrack("in", weatherTrack)
-        local duration = mData.faderConfig["in"].duration
+        local duration = moduleData[moduleName].faderConfig["in"].duration
         timer.start { duration = duration + 0.2, callback = function() cellData.isWeatherVolumeDynamic = false end }
     end
 end

--- a/00 Core/MWSE/mods/tew/AURA/fader.lua
+++ b/00 Core/MWSE/mods/tew/AURA/fader.lua
@@ -132,6 +132,7 @@ function this.fade(options)
             reference = ref,
             volume = currentVolume,
             inOrOut = fadeType,
+            quiet = not (((iterCount % 10) == 0) or (iterCount == 1) or (iterCount == iters)),
         }
     end
 
@@ -159,12 +160,7 @@ function this.fade(options)
                 end
             end
             common.setRemove(this.inProgress[fadeType], fadeInProgress)
-            if mData then
-                mData.old = track
-                mData.oldRef = ref
-                mData.lastVolume = currentVolume
-                debugLog(string.format("[%s] lastVolume is now: %s", moduleName, currentVolume))
-            end
+            debugLog(string.format("[%s] lastVolume is now: %s", moduleName, currentVolume))
         end,
     }
     common.setInsert(this.inProgress[fadeType], fadeInProgress)

--- a/00 Core/MWSE/mods/tew/AURA/volumeController.lua
+++ b/00 Core/MWSE/mods/tew/AURA/volumeController.lua
@@ -134,6 +134,7 @@ function this.adjustVolume(options)
     local targetVolume = options.volume
     local inOrOut = options.inOrOut or ""
     local config = options.config
+    local quiet = options.quiet
 
     local function adjust(track, ref)
         local attached = (track and ref) and tes3.getSoundPlaying { sound = track, reference = ref }
@@ -141,9 +142,11 @@ function this.adjustVolume(options)
         if not (attached or unattached) then return end
 
         local volume = targetVolume or this.getVolume { module = moduleName, config = config }
-        local msgPrefix = string.format("Adjusting volume %s", inOrOut):gsub("%s+$", "")
-        debugLog(string.format("%s for module %s: %s -> %s | %.3f", msgPrefix, moduleName, track.id,
-            ref or "(unattached)", volume))
+        if not quiet then
+            local msgPrefix = string.format("Adjusting volume %s", inOrOut):gsub("%s+$", "")
+            debugLog(string.format("%s for module %s: %s -> %s | %.3f", msgPrefix, moduleName, track.id,
+                ref or "(unattached)", volume))
+        end
         if attached then
             tes3.adjustSoundVolume {
                 sound = track,
@@ -153,7 +156,7 @@ function this.adjustVolume(options)
         elseif unattached then
             this.setVolume(track, volume)
         end
-        if mData then mData.lastVolume = volume end
+        if mData then moduleData[moduleName].lastVolume = volume end
     end
 
     if adjustAllWindoors then


### PR DESCRIPTION
I'm not sure I can even explain this. During my recent playtest I came across what seemed to be an inoffensive bug that quickly spiraled into a cascade of bizarre edge cases that dragged me into a state of confusion i'm still not sure i fully recovered from lol

The initial bug was crossfade wasn't working as expected because the queue was advancing **after** and not before resolving the `oldTrack`, then I realized that the fader is doing stuff it shouldn't do, then I thought wait, `playImmediate` should in fact handle some of this, then I reflected on my incompetence in distinguishing between assigning data to globally accessible tables versus assigning to a local copy of said tables, then I ... 

Good grief! I need a KitKat 😀 