### PR TITLE
Proper checks for interiors behaving as exteriors

### DIFF
--- a/00 Core/MWSE/mods/tew/AURA/Ambient/Interior/interiorMain.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Ambient/Interior/interiorMain.lua
@@ -108,7 +108,7 @@ local function cellCheck()
             if (door ~= nil) and (door.destination.cell == cell) then
                 local doorTrack = modules.getExteriorDoorTrack(door)
                 if doorTrack then
-                    local doorIntOrExt = door.cell.isInterior and "Interior" or "Exterior"
+                    local doorIntOrExt = door.cell.isOrBehavesAsExterior and "Exterior" or "Interior"
                     debugLog(string.format("%s->Interior transition, using last known door track.", doorIntOrExt))
                     track = tes3.getSound(doorTrack.id:lower():gsub("^ie_", "i_"))
                     break
@@ -160,7 +160,7 @@ end
 -- sounds will be removed and exterior doors won't play anymore.
 local function deathCheck(e)
     local modData = tes3.player.data.AURA
-    local cellId = cellData.cell and cellData.cell.isInterior and cellData.cell.id:lower()
+    local cellId = cellData.cell and not cellData.cell.isOrBehavesAsExterior and cellData.cell.id:lower()
     local cellType = cellId and modData.visitedInteriorCells[cellId] and modData.visitedInteriorCells[cellId].type
     if cellType and not data.statics[cellType] and e.reference and e.reference.baseObject.objectType == tes3.objectType.npc then
         debugLog("NPC died in appropriate interior, running cell check.")

--- a/00 Core/MWSE/mods/tew/AURA/Ambient/Interior/interiorToExterior.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Ambient/Interior/interiorToExterior.lua
@@ -29,8 +29,8 @@ local function cellCheck()
     local cell = tes3.getPlayerCell()
     if not cell then return end
 
-    if (cell.isInterior)
-        or (cellLast and cellLast.isInterior and cell.isOrBehavesAsExterior) then
+    if (not cell.isOrBehavesAsExterior)
+        or (cellLast and not cellLast.isOrBehavesAsExterior and cell.isOrBehavesAsExterior) then
         table.clear(cellData.exteriorDoors)
     end
 
@@ -40,7 +40,7 @@ local function cellCheck()
     debugLog("Searching for eligible doors.")
 
     for door in cell:iterateReferences(tes3.objectType.door) do
-        if not (door.destination and door.destination.cell and door.destination.cell.isInterior and door.tempData) then
+        if not (door.destination and door.destination.cell and not door.destination.cell.isOrBehavesAsExterior and door.tempData) then
             goto nextDoor
         end
         local cellId = door.destination.cell.id:lower()

--- a/00 Core/MWSE/mods/tew/AURA/Ambient/Outdoor/outdoorMain.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Ambient/Outdoor/outdoorMain.lua
@@ -35,7 +35,7 @@ local function updateConditions(resetTimerFlag)
 
 	if resetTimerFlag
 		and interiorTimer
-		and cell.isInterior
+		and not cell.isOrBehavesAsExterior
 		and not table.empty(cellData.windoors) then
 		interiorTimer:reset()
 	end

--- a/00 Core/MWSE/mods/tew/AURA/Misc/thunderSounds.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Misc/thunderSounds.lua
@@ -15,7 +15,7 @@ end
 local function onSoundObjectPlay(e)
 
     if not cellData.cell
-    or cellData.cell.isInterior
+    or not cellData.cell.isOrBehavesAsExterior
 	or not e.sound or not isVanillaThunder(e.sound.id) then
         return
     end

--- a/00 Core/MWSE/mods/tew/AURA/Misc/windSounds.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Misc/windSounds.lua
@@ -33,7 +33,7 @@ end
 local function updateConditions(resetTimerFlag)
 	if resetTimerFlag
 	and interiorTimer
-	and cell.isInterior
+	and not cell.isOrBehavesAsExterior
 	and not table.empty(cellData.windoors) then
 		interiorTimer:reset()
 	end

--- a/00 Core/MWSE/mods/tew/AURA/Sounds On Statics/staticsMain.lua
+++ b/00 Core/MWSE/mods/tew/AURA/Sounds On Statics/staticsMain.lua
@@ -417,7 +417,7 @@ end
 
 
 local function conditionsAreMet()
-    return cellData.cell and not cellData.cell.isInterior
+    return cellData.cell and cellData.cell.isOrBehavesAsExterior
 end
 
 local function tick()

--- a/00 Core/MWSE/mods/tew/AURA/common.lua
+++ b/00 Core/MWSE/mods/tew/AURA/common.lua
@@ -100,12 +100,10 @@ end
 function this.checkCellDiff(cell, cellLast)
 	if (cellLast == nil) then return true end
 
-	if (cell.isInterior) and (cellLast.isOrBehavesAsExterior)
-		or (cell.isOrBehavesAsExterior) and (cellLast.isInterior) then
-		return true
-	end
-
-	return false
+	return (cell.isOrBehavesAsExterior and not cellLast.isOrBehavesAsExterior)
+		or (cellLast.isOrBehavesAsExterior and not cell.isOrBehavesAsExterior)
+		or (cell.isInterior and not cellLast.isInterior)
+		or (cellLast.isInterior and not cell.isInterior)
 end
 
 -- Pass me the cell and cell type array and I'll tell you if it matches --

--- a/00 Core/MWSE/mods/tew/AURA/volumeController.lua
+++ b/00 Core/MWSE/mods/tew/AURA/volumeController.lua
@@ -32,7 +32,7 @@ function this.getModuleSoundConfig(moduleName)
     local rainType = cellData.rainType[weather]
     local interiorType = common.getInteriorType(cellData.cell)
     local exterior = cell and cell.isOrBehavesAsExterior and "exterior"
-    local interior = cell and cell.isInterior and "interior"
+    local interior = cell and not cell.isOrBehavesAsExterior and "interior"
 
     return (exterior and soundConfig[exterior])
         or (interior and soundConfig[interior])
@@ -98,7 +98,7 @@ function this.getVolume(options)
             end
         end
 
-        if cellData.cell.isInterior then
+        if not cellData.cell.isOrBehavesAsExterior then
             if (interiorType == "big") then
                 debugLog(string.format("[%s] Applying big interior mult.", moduleName))
                 volume = (config.volumes.modules[moduleName].big * volume) - (windoorsMult * #cellData.windoors)

--- a/00 Core/MWSE/mods/tew/AURA/volumeSave.lua
+++ b/00 Core/MWSE/mods/tew/AURA/volumeSave.lua
@@ -120,7 +120,7 @@ end
 
 local function doExtremes()
     local cw = tes3.worldController.weatherController.currentWeather
-    if (not this.cell.isInterior) and (cw) and (cw.index == 6 or cw.index == 7 or cw.index == 9) then
+    if (this.cell.isOrBehavesAsExterior) and (cw) and (cw.index == 6 or cw.index == 7 or cw.index == 9) then
         local menu = tes3ui.findMenu(this.id_menu)
         local track
         if cw.name == "Ashstorm" then
@@ -162,7 +162,7 @@ end
 local function doRain()
     local track, rainType
     local cw = tes3.worldController.weatherController.currentWeather
-    if (not this.cell.isInterior) and cw and cw.rainLoopSound and cw.rainLoopSound:isPlaying() then
+    if (this.cell.isOrBehavesAsExterior) and cw and cw.rainLoopSound and cw.rainLoopSound:isPlaying() then
         track = cw.rainLoopSound
         rainType = cellData.rainType[cw.index]
         if not rainType then return end -- Needs variable rain sounds. TODO: maybe add tooltip
@@ -232,7 +232,7 @@ local function doModules()
         sc.volumeTableDefault = defaults.volumes.modules[moduleName]
         sc.volumeTableCurrent = this.config.volumes.modules[moduleName]
 
-        if this.cell.isInterior
+        if not this.cell.isOrBehavesAsExterior
             and (moduleName ~= "interiorToExterior")
             and (moduleName ~= "interiorWeather")
             and (moduleName ~= "interior") then
@@ -287,11 +287,11 @@ local function updateHeader()
     local cellType
     if (trackList) and (this.entries > 0) and cellData.playerUnderwater then
         hLabel.text = messages.adjustForUnderwater
-    elseif (trackList) and (this.entries > 0) and this.cell.isInterior then
+    elseif (trackList) and (this.entries > 0) and not this.cell.isOrBehavesAsExterior then
         cellType = common.getInteriorType(this.cell):gsub("^sma$", messages.small):gsub("^ten$", messages.small):gsub(
         "^big$", messages.big)
         hLabel.text = string.format("%s (%s)", messages.adjustForInterior, cellType)
-    elseif (trackList) and (this.entries > 0) and not this.cell.isInterior then
+    elseif (trackList) and (this.entries > 0) and this.cell.isOrBehavesAsExterior then
         hLabel.text = messages.adjustForExterior
     else
         hLabel.text = messages.noTracksPlaying


### PR DESCRIPTION
Previously our modules would become stale after loading an interior-that-behaves-as-exterior and the volume adjuster would not show any track info. Tracks would play on initial cell check, but would be removed on a subsequent check because `common.checkCellDiff` did not take into account the "behaves as exterior" part on the ".isInterior" check. Similarly, proper checks for this were missing in volumeController.lua and a bunch of other places.