### PR TITLE
SOUNDS: Keep track of references as safe handles

### DIFF
--- a/00 Core/MWSE/mods/tew/AURA/modules.lua
+++ b/00 Core/MWSE/mods/tew/AURA/modules.lua
@@ -370,7 +370,7 @@ function this.getCurrentlyPlaying(moduleName)
         end
     end
     if oldRefHandle then
-        local oldRef = newRefHandle:getObject()
+        local oldRef = oldRefHandle:getObject()
         if common.getTrackPlaying(oldTrack, oldRef) then
             return { oldTrack, oldRef }
         end

--- a/00 Core/MWSE/mods/tew/AURA/modules.lua
+++ b/00 Core/MWSE/mods/tew/AURA/modules.lua
@@ -358,6 +358,7 @@ this.data = {
 }
 
 function this.getCurrentlyPlaying(moduleName)
+    if not this.data[moduleName] then return end
     local oldTrack = this.data[moduleName].old
     local newTrack = this.data[moduleName].new
     local oldRefHandle = this.data[moduleName].oldRefHandle
@@ -378,6 +379,7 @@ function this.getCurrentlyPlaying(moduleName)
 end
 
 function this.getWindoorPlaying(moduleName)
+    if not this.data[moduleName] then return end
     if not this.data[moduleName].playWindoors
         or not cellData.windoors
         or table.empty(cellData.windoors) then
@@ -406,6 +408,7 @@ function this.getExteriorDoorTrack(ref)
 end
 
 function this.getExteriorDoorPlaying(moduleName)
+    if not this.data[moduleName] then return end
     if not this.data[moduleName].playExteriorDoors
         or not cellData.exteriorDoors
         or table.empty(cellData.exteriorDoors) then
@@ -422,6 +425,7 @@ function this.getExteriorDoorPlaying(moduleName)
 end
 
 function this.getEligibleWeather(moduleName)
+    if not this.data[moduleName] then return end
     local regionObject = common.getRegion()
     local weather = regionObject and regionObject.weather.index
     local blockedWeathers = this.data[moduleName].blockedWeathers
@@ -431,6 +435,7 @@ function this.getEligibleWeather(moduleName)
 end
 
 function this.isActive(moduleName)
+    if not this.data[moduleName] then return end
     return this.data[moduleName].active
 end
 

--- a/00 Core/MWSE/mods/tew/AURA/modules.lua
+++ b/00 Core/MWSE/mods/tew/AURA/modules.lua
@@ -9,8 +9,8 @@ this.data = {
         active = config.moduleAmbientOutdoor,
         old = nil,
         new = nil,
-        oldRef = nil,
-        newRef = nil,
+        oldRefHandle = nil,
+        newRefHandle = nil,
         lastVolume = nil,
         playWindoors = true,
         playUnderwater = true,
@@ -53,8 +53,8 @@ this.data = {
         active = config.moduleAmbientPopulated,
         old = nil,
         new = nil,
-        oldRef = nil,
-        newRef = nil,
+        oldRefHandle = nil,
+        newRefHandle = nil,
         lastVolume = nil,
         playUnderwater = true,
         blockedWeathers = {
@@ -74,8 +74,8 @@ this.data = {
         active = config.moduleAmbientInterior,
         old = nil,
         new = nil,
-        oldRef = nil,
-        newRef = nil,
+        oldRefHandle = nil,
+        newRefHandle = nil,
         lastVolume = nil,
         playUnderwater = true,
         soundConfig = {},
@@ -85,8 +85,8 @@ this.data = {
         active = config.moduleAmbientInterior and config.moduleInteriorToExterior,
         old = nil,
         new = nil,
-        oldRef = nil,
-        newRef = nil,
+        oldRefHandle = nil,
+        newRefHandle = nil,
         lastVolume = nil,
         playExteriorDoors = true,
         playUnderwater = false,
@@ -100,8 +100,8 @@ this.data = {
         active = config.moduleInteriorWeather,
         old = nil,
         new = nil,
-        oldRef = nil,
-        newRef = nil,
+        oldRefHandle = nil,
+        newRefHandle = nil,
         lastVolume = nil,
         playWindoors = true,
         playUnderwater = true,
@@ -141,8 +141,8 @@ this.data = {
         active = config.windSounds,
         old = nil,
         new = nil,
-        oldRef = nil,
-        newRef = nil,
+        oldRefHandle = nil,
+        newRefHandle = nil,
         lastVolume = nil,
         playWindoors = true,
         playUnderwater = true,
@@ -187,8 +187,8 @@ this.data = {
         active = config.playRainOnStatics,
         old = nil,
         new = nil,
-        oldRef = nil,
-        newRef = nil,
+        oldRefHandle = nil,
+        newRefHandle = nil,
         lastVolume = nil,
         playUnderwater = false,
         blockedWeathers = {
@@ -221,8 +221,8 @@ this.data = {
         active = config.playRainInsideShelter,
         old = nil,
         new = nil,
-        oldRef = nil,
-        newRef = nil,
+        oldRefHandle = nil,
+        newRefHandle = nil,
         lastVolume = nil,
         playUnderwater = false,
         blockedWeathers = {
@@ -255,8 +255,8 @@ this.data = {
         active = config.playWindInsideShelter,
         old = nil,
         new = nil,
-        oldRef = nil,
-        newRef = nil,
+        oldRefHandle = nil,
+        newRefHandle = nil,
         lastVolume = nil,
         playUnderwater = false,
         blockedWeathers = {
@@ -287,8 +287,8 @@ this.data = {
         active = config.shelterWeather,
         old = nil,
         new = nil,
-        oldRef = nil,
-        newRef = nil,
+        oldRefHandle = nil,
+        newRefHandle = nil,
         lastVolume = nil,
         playUnderwater = false,
         blockedWeathers = {
@@ -321,24 +321,24 @@ this.data = {
         active = config.playRopeBridge,
         old = nil,
         new = nil,
-        oldRef = nil,
-        newRef = nil,
+        oldRefHandle = nil,
+        newRefHandle = nil,
         lastVolume = nil,
     },
     ["photodragons"] = {
         active = config.playPhotodragons,
         old = nil,
         new = nil,
-        oldRef = nil,
-        newRef = nil,
+        oldRefHandle = nil,
+        newRefHandle = nil,
         lastVolume = nil,
     },
     ["bannerFlap"] = {
         active = config.playBannerFlap,
         old = nil,
         new = nil,
-        oldRef = nil,
-        newRef = nil,
+        oldRefHandle = nil,
+        newRefHandle = nil,
         lastVolume = nil,
         soundConfig = {
             -- 0-4 and 8: light breeze
@@ -360,14 +360,20 @@ this.data = {
 function this.getCurrentlyPlaying(moduleName)
     local oldTrack = this.data[moduleName].old
     local newTrack = this.data[moduleName].new
-    local oldRef = this.data[moduleName].oldRef
-    local newRef = this.data[moduleName].newRef
+    local oldRefHandle = this.data[moduleName].oldRefHandle
+    local newRefHandle = this.data[moduleName].newRefHandle
 
-    if common.getTrackPlaying(newTrack, newRef) then
-        return { newTrack, newRef }
+    if newRefHandle then
+        local newRef = newRefHandle:getObject()
+        if common.getTrackPlaying(newTrack, newRef) then
+            return { newTrack, newRef }
+        end
     end
-    if common.getTrackPlaying(oldTrack, oldRef) then
-        return { oldTrack, oldRef }
+    if oldRefHandle then
+        local oldRef = newRefHandle:getObject()
+        if common.getTrackPlaying(oldTrack, oldRef) then
+            return { oldTrack, oldRef }
+        end
     end
 end
 

--- a/00 Core/MWSE/mods/tew/AURA/volumeController.lua
+++ b/00 Core/MWSE/mods/tew/AURA/volumeController.lua
@@ -129,8 +129,10 @@ function this.adjustVolume(options)
     not options.reference
     local isTrackUnattached = options.track and not options.reference
 
-    local targetTrack = options.track or (mData and mData.new)
-    local targetRef = options.reference or (mData and mData.newRef)
+    local playing = modules.getCurrentlyPlaying(moduleName) or {}
+    local currentTrack, currentRef = table.unpack(playing)
+    local targetTrack = options.track or currentTrack
+    local targetRef = options.reference or currentRef
     local targetVolume = options.volume
     local inOrOut = options.inOrOut or ""
     local config = options.config


### PR DESCRIPTION
Fixes CTD when trying to resolve a reference that's no longer valid during `sounds.play` crossfade phase (can happen when loading a save with a different cell that the current one)