### PR TITLE
VOLSAVE: Fix multiple entries with same track

### DIFF
--- a/00 Core/MWSE/mods/tew/AURA/volumeSave.lua
+++ b/00 Core/MWSE/mods/tew/AURA/volumeSave.lua
@@ -398,6 +398,10 @@ local function doModules()
             configOption = "moduleAmbientInterior"
             sc.sliderType = sliderPercent
         elseif moduleName == "interiorWeather" then
+            if isExterior then
+                entry:destroy()
+                goto nextModule
+            end
             configOption = "moduleInteriorWeather"
             sc.sliderType = sliderPercent
         elseif moduleName == "interiorToExterior" then
@@ -438,9 +442,17 @@ local function doModules()
             configOption = "playRainOnStatics"
             sc.sliderType = sliderPercent
         elseif moduleName == "shelterRain" then
+            if not isExterior then
+                entry:destroy()
+                goto nextModule
+            end
             configOption = "playRainInsideShelter"
             sc.sliderType = sliderPercent
         elseif moduleName == "shelterWind" then
+            if not isExterior then
+                entry:destroy()
+                goto nextModule
+            end
             configOption = "playWindInsideShelter"
             sc.sliderType = sliderPercent
         elseif moduleName == "ropeBridge" then


### PR DESCRIPTION
Exterior <--> interior tent cell transitions during rain results in double entries in volume adjuster since SHRAIN and IW share the same track (and the same ref if the interior cell is a tent). The root cause of this will eventually have to be addressed properly (`.old`/`.new` and `modules.getCurrentlyPlaying` is kinda shabby).